### PR TITLE
fix: copy paths.yaml to paths.json

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -1,0 +1,15 @@
+{
+  "mappings": [
+    "/content/24petwatch/us/en:/",
+    "/content/24petwatch/ca/en:/ca",
+    "/content/experience-fragments/24petwatch/us/en/site/:/fragments/",
+    "/content/dam/24-petwatch/crosswalk/headers.json:/.helix/headers.json"
+  ],
+  "includes": [
+    "/content/24petwatch/us/en",
+    "/content/24petwatch/ca/en",
+    "/content/experience-fragments/24petwatch/us/en/site/header",
+    "/content/experience-fragments/24petwatch/us/en/site/footer",
+    "/content/dam/24-petwatch/crosswalk"
+  ]
+}


### PR DESCRIPTION
We are transitioning from using paths.yaml to paths.json. This will remain a copy for now.